### PR TITLE
Feature: setting --auth-mode=server

### DIFF
--- a/charts/argo-workflows/values.yaml
+++ b/charts/argo-workflows/values.yaml
@@ -463,13 +463,13 @@ server:
     #   value: "bar"
 
   # -- Extra arguments to provide to the Argo server binary, such as for disabling authentication.
-  extraArgs: []
+  # extraArgs: []
   # If you want to disable authentication for purposes such as:
   #   - local dev-mode without authentication
   #   - gateway authentication through some other service such as KeyCloak
   # uncomment the lines below and comment out the default empty list `extraArgs: []` above:
-  # extraArgs:
-  # - --auth-mode=server
+  extraArgs:
+  - --auth-mode=server
 
   logging:
     # -- Set the logging level (one of: `debug`, `info`, `warn`, `error`)


### PR DESCRIPTION
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [ ] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

Changes are automatically published when merged to `main`. They are not published on branches.
